### PR TITLE
画像アップロードのためのUsecase作成

### DIFF
--- a/android/domain/src/main/java/com/fernandocejas/android10/sample/domain/Face.kt
+++ b/android/domain/src/main/java/com/fernandocejas/android10/sample/domain/Face.kt
@@ -1,0 +1,11 @@
+package com.fernandocejas.android10.sample.domain
+
+import java.net.URI
+
+/**
+ * Class that represents a Face in the domain layer.
+ *
+ * Created on 8/13/17.
+ */
+class Face constructor(val image: URI) {
+}

--- a/android/domain/src/main/java/com/fernandocejas/android10/sample/domain/interactor/PostFace.kt
+++ b/android/domain/src/main/java/com/fernandocejas/android10/sample/domain/interactor/PostFace.kt
@@ -1,0 +1,25 @@
+package com.fernandocejas.android10.sample.domain.interactor
+
+import com.fernandocejas.android10.sample.domain.Face
+import com.fernandocejas.android10.sample.domain.executor.PostExecutionThread
+import com.fernandocejas.android10.sample.domain.executor.ThreadExecutor
+import com.fernandocejas.android10.sample.domain.repository.FaceRepository
+import io.reactivex.Observable
+import javax.inject.Inject
+
+/**
+ * This class is an implementation of {@link UseCase} that represents a use case for
+ * face date sever.
+ *
+ * Created on 8/13/17.
+ */
+class PostFace @Inject constructor(
+    val faceRepository: FaceRepository,
+    val threadExecutor: ThreadExecutor,
+    val postExecutionThread: PostExecutionThread
+) : UseCase<Face, Void>(threadExecutor, postExecutionThread) {
+
+  override public fun buildUseCaseObservable(params: Void?): Observable<Face> {
+    return this.faceRepository.face();
+  }
+}

--- a/android/domain/src/main/java/com/fernandocejas/android10/sample/domain/repository/FaceRepository.kt
+++ b/android/domain/src/main/java/com/fernandocejas/android10/sample/domain/repository/FaceRepository.kt
@@ -1,0 +1,16 @@
+package com.fernandocejas.android10.sample.domain.repository
+
+import com.fernandocejas.android10.sample.domain.Face
+import io.reactivex.Observable
+
+/**
+ * Interface that represents a Repository for getting [@link Face] related data.
+ *
+ * Created on 8/13/17.
+ */
+interface FaceRepository {
+  /**
+   * Get an [Observable] which will emit a [@link Profile] Image uri.
+   */
+  fun face(): Observable<Face>
+}

--- a/android/domain/src/test/java/com/fernandocejas/android10/sample/domain/FaceTest.kt
+++ b/android/domain/src/test/java/com/fernandocejas/android10/sample/domain/FaceTest.kt
@@ -1,0 +1,22 @@
+package com.fernandocejas.android10.sample.domain
+
+import org.assertj.core.api.Assertions
+import org.junit.Before
+import org.junit.Test
+import java.net.URI
+
+class FaceTest {
+  val FAKE_IMAGE_URI: URI = URI("Test")
+  lateinit var face: Face
+
+  @Before
+  fun setUp() {
+    this.face = Face(this.FAKE_IMAGE_URI)
+  }
+
+  @Test
+  fun testFaceConstructorHappyCase() {
+    val faceImageURI :URI = face.image
+    Assertions.assertThat(FAKE_IMAGE_URI).isEqualTo(faceImageURI)
+  }
+}

--- a/android/domain/src/test/java/com/fernandocejas/android10/sample/domain/interactor/PostFaceTest.kt
+++ b/android/domain/src/test/java/com/fernandocejas/android10/sample/domain/interactor/PostFaceTest.kt
@@ -1,0 +1,33 @@
+package com.fernandocejas.android10.sample.domain.interactor
+
+import com.fernandocejas.android10.sample.domain.executor.PostExecutionThread
+import com.fernandocejas.android10.sample.domain.executor.ThreadExecutor
+import com.fernandocejas.android10.sample.domain.repository.FaceRepository
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class PostFaceTest {
+  lateinit var mockThreadExecutor: ThreadExecutor
+  lateinit var mockPostExecutionThread: PostExecutionThread
+  lateinit var mockFaceRepository: FaceRepository
+  lateinit var postFace: PostFace
+
+  @Before
+  fun setUp() {
+    mockThreadExecutor = Mockito.mock(ThreadExecutor::class.java)
+    mockPostExecutionThread = Mockito.mock(PostExecutionThread::class.java)
+    mockFaceRepository = Mockito.mock(FaceRepository::class.java)
+    postFace = PostFace(mockFaceRepository, mockThreadExecutor, mockPostExecutionThread)
+  }
+
+  @Test
+  fun testPostFaceUseCaseObserverHappyCase() {
+    postFace.buildUseCaseObservable(null)
+
+    Mockito.verify(mockFaceRepository).face()
+  }
+}


### PR DESCRIPTION
### 関連
#65 

### やったこと
- Faceクラスの作成(画像URIを保持するクラス)
- FaceRespositoryの作成(Presentation, DataPackageはこれを通してFaceクラス等を扱う
- PostFaceクラスの作成(Usecase)
- テストの作成

### 見た目の変更点
- 特になし
